### PR TITLE
移动端适配

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -293,3 +293,26 @@
   left: 80px;
   z-index: 99999;
 }
+
+@media (max-width: 767px) {
+  .book-interface {
+    top: 0;
+    padding: 0.75rem;
+    gap: 1rem;
+  }
+
+  .book-page.right-page {
+    padding: 1rem;
+  }
+
+  .book-page.right-page > * {
+    margin-left: 0.75rem;
+  }
+
+  .voice-input-modal {
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
   FaSync,
   FaBrain, FaHeart, FaQuestion, FaCloud, FaTheaterMasks, FaEye,
   FaFistRaised, FaLightbulb, FaShieldAlt, FaWind, FaFire, FaCompass,
+  FaPenNib, FaRegClock, FaChartBar, FaLayerGroup, FaCog,
 } from 'react-icons/fa';
 import TopNavBar from './components/TopNavBar';
 import LeftToolbar from './components/LeftToolbar';
@@ -91,6 +92,15 @@ export default function App() {
   const isMobile = useMobile();
   const { isAuthenticated, isLoading } = useAuth();
   const { t, i18n } = useTranslation();
+  const mobileNavHeight = 64;
+  const mobileBottomOffset = isMobile
+    ? `calc(${mobileNavHeight}px + env(safe-area-inset-bottom, 0px))`
+    : '0px';
+  const mobileTopInset = isMobile ? 'env(safe-area-inset-top, 0px)' : '48px';
+  const viewTopOffset = isMobile ? 0 : 48;
+  const writingBottomPadding = isMobile
+    ? `calc(${mobileNavHeight}px + env(safe-area-inset-bottom, 0px) + 12px)`
+    : '41px';
 
   // @@@ Auth screen state
   const [authScreen, setAuthScreen] = useState<'login' | 'register'>('login');
@@ -250,6 +260,13 @@ export default function App() {
   const [showFullEnergy, setShowFullEnergy] = useState(false);
   const fullEnergyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const energyProgress = showFullEnergy ? 1 : energyRemainder / energyThreshold;
+  const mobileNavItems = [
+    { key: 'writing' as const, label: t('nav.writing'), icon: FaPenNib },
+    { key: 'timeline' as const, label: t('nav.timeline'), icon: FaRegClock },
+    { key: 'analysis' as const, label: t('nav.analysis'), icon: FaChartBar },
+    { key: 'decks' as const, label: t('nav.decks'), icon: FaLayerGroup },
+    { key: 'settings' as const, label: t('nav.settings'), icon: FaCog },
+  ];
 
   useEffect(() => {
     const prevLevel = energyLevelRef.current;
@@ -1085,8 +1102,8 @@ export default function App() {
         <div style={{
           display: 'flex',
           height: '100vh',
-          paddingTop: isMobile ? '0' : '48px',
-          paddingBottom: '41px',  // @@@ Space for fixed stats bar at bottom
+          paddingTop: mobileTopInset,
+          paddingBottom: writingBottomPadding,  // @@@ Space for fixed stats bar + mobile nav
           fontFamily: 'system-ui, -apple-system, sans-serif',
           boxSizing: 'border-box'
         }}>
@@ -1152,7 +1169,7 @@ export default function App() {
           {isMobile && (
             <div style={{
               position: 'fixed',
-              top: '10px',
+              top: 'calc(10px + env(safe-area-inset-top, 0px))',
               right: '10px',
               display: 'flex',
               gap: '8px',
@@ -1233,7 +1250,9 @@ export default function App() {
                   overflow: 'auto',
                   padding: '20px',
                   paddingLeft: isMobile ? '20px' : '80px',  // @@@ Extra left padding for floating toolbar
-                  paddingBottom: '80px',  // Extra space for smooth scrolling to bottom
+                  paddingBottom: isMobile
+                    ? `calc(80px + ${mobileNavHeight}px + env(safe-area-inset-bottom, 0px))`
+                    : '80px',  // Extra space for smooth scrolling to bottom
                   backgroundColor: '#fffef9'  // @@@ Cream paper background for notebook lines
                 }}>
                 <div style={{
@@ -1429,7 +1448,7 @@ export default function App() {
                 {isMobile && mobileActiveComment && (
                   <div style={{
                     position: 'fixed',
-                    bottom: '20px',
+                    bottom: `calc(${mobileNavHeight}px + 20px + env(safe-area-inset-bottom, 0px))`,
                     left: '10px',
                     right: '10px',
                     background: '#fff',
@@ -1471,15 +1490,16 @@ export default function App() {
               {/* Debug stats bar at bottom */}
               <div style={{
                 position: 'fixed',
-                bottom: 0,
+                bottom: isMobile ? mobileBottomOffset : 0,
                 left: 0,
                 right: 0,
-                padding: '10px 20px',
+                padding: isMobile ? '8px 12px' : '10px 20px',
                 borderTop: '1px solid #e0e0e0',
-                fontSize: '12px',
+                fontSize: isMobile ? '11px' : '12px',
                 color: '#666',
                 display: 'flex',
-                gap: '20px',
+                gap: isMobile ? '12px' : '20px',
+                flexWrap: isMobile ? 'wrap' : 'nowrap',
                 backgroundColor: '#fafafa',
                 zIndex: 50
               }}>
@@ -1499,7 +1519,7 @@ export default function App() {
                       }}
                     >
                       <span style={{
-                        width: '120px',
+                        width: isMobile ? '84px' : '120px',
                         height: '8px',
                         borderRadius: '999px',
                         background: 'rgba(102, 102, 102, 0.2)',
@@ -1538,10 +1558,10 @@ export default function App() {
       {currentView === 'decks' && (
         <div style={{
           position: 'fixed',
-          top: 48,
+          top: viewTopOffset,
           left: 0,
           right: 0,
-          bottom: 0,
+          bottom: mobileBottomOffset,
           background: '#f8f0e6',
           display: 'flex',
           overflow: 'hidden'
@@ -1565,13 +1585,13 @@ export default function App() {
           flex: 1,
           display: 'flex',
           justifyContent: 'center',
-          padding: '60px 40px 120px 40px',
+          padding: isMobile ? '24px 16px 120px 16px' : '60px 40px 120px 40px',
           overflow: 'auto',
           position: 'fixed',
-          top: 48,
+          top: viewTopOffset,
           left: 0,
           right: 0,
-          bottom: 0,
+          bottom: mobileBottomOffset,
           background: '#f8f0e6'
         }}>
           <div style={{
@@ -1699,7 +1719,8 @@ export default function App() {
                       <span style={{
                         position: 'absolute',
                         top: 3,
-                        left: showEnergyBar ? 24 : 4,
+                        left: showEnergyBar ? 'auto' : 4,
+                        right: showEnergyBar ? 4 : 'auto',
                         width: 16,
                         height: 16,
                         borderRadius: '50%',
@@ -1720,10 +1741,10 @@ export default function App() {
       {/* @@@ Always render timeline to pre-load data and position scroll */}
       <div style={{
         position: 'fixed',
-        top: 48,
+        top: viewTopOffset,
         left: 0,
         right: 0,
-        bottom: 0,
+        bottom: mobileBottomOffset,
         background: '#f8f0e6',
         display: currentView === 'timeline' ? 'flex' : 'none',
         overflow: 'hidden'
@@ -1737,16 +1758,64 @@ export default function App() {
       {currentView === 'analysis' && (
         <div style={{
           position: 'fixed',
-          top: 48,
+          top: viewTopOffset,
           left: 0,
           right: 0,
-          bottom: 0,
+          bottom: mobileBottomOffset,
           background: '#f8f0e6',
           display: 'flex',
           overflow: 'hidden'
         }}>
           <AnalysisView />
         </div>
+      )}
+
+      {isMobile && (
+        <nav style={{
+          position: 'fixed',
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: `calc(${mobileNavHeight}px + env(safe-area-inset-bottom, 0px))`,
+          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+          background: '#f8f0e6',
+          borderTop: '1px solid #d0c4b0',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-around',
+          zIndex: 900
+        }}>
+          {mobileNavItems.map((item) => {
+            const isActive = currentView === item.key;
+            const Icon = item.icon;
+            return (
+              <button
+                key={item.key}
+                onClick={() => setCurrentView(item.key)}
+                aria-pressed={isActive}
+                style={{
+                  flex: 1,
+                  height: '100%',
+                  border: 'none',
+                  background: 'transparent',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 4,
+                  color: isActive ? '#2c2c2c' : '#8a7a69',
+                  fontSize: 11,
+                  fontWeight: isActive ? 600 : 400,
+                  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+                  cursor: isActive ? 'default' : 'pointer'
+                }}
+              >
+                <Icon size={18} />
+                <span>{item.label}</span>
+              </button>
+            );
+          })}
+        </nav>
       )}
 
       {/* Warning Dialog */}

--- a/frontend/src/components/AnalysisView.tsx
+++ b/frontend/src/components/AnalysisView.tsx
@@ -4,6 +4,7 @@ import { analyzeEchoes, analyzeTraits, analyzePatterns, saveAnalysisReport, getA
 import { useAuth } from '../contexts/AuthContext';
 import { STORAGE_KEYS } from '../constants/storageKeys';
 import { getDateLocale } from '../i18n';
+import { useMobile } from '../utils/mobileDetect';
 
 // @@@ Constants
 const MAX_SAVED_REPORTS = 10;
@@ -44,6 +45,7 @@ export default function AnalysisView() {
   const { isAuthenticated } = useAuth();
   const { t, i18n } = useTranslation();
   const dateLocale = getDateLocale(i18n.language);
+  const isMobile = useMobile();
   const formatDaysLabel = (count: number) => t('analysis.statsLabels.daysCount', { count });
   const formatEntriesLabel = (count: number) => t('analysis.statsLabels.entriesCount', { count });
   const formatWordsLabel = (value: number) => t('analysis.statsLabels.wordsCount', { value: value.toLocaleString() });
@@ -265,9 +267,9 @@ export default function AnalysisView() {
           onClick={() => setViewMode('dashboard')}
           style={{
             position: 'absolute',
-            top: '2rem',
-            left: '2rem',
-            padding: '12px 24px',
+            top: isMobile ? '1rem' : '2rem',
+            left: isMobile ? '1rem' : '2rem',
+            padding: isMobile ? '10px 16px' : '12px 24px',
             borderRadius: '24px',
             background: 'linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(255,250,240,0.9) 100%)',
             border: '2px solid rgba(139,115,85,0.25)',
@@ -309,8 +311,8 @@ export default function AnalysisView() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '2rem',
-          marginTop: '-60px'
+          padding: isMobile ? '1rem' : '2rem',
+          marginTop: isMobile ? '0' : '-60px'
         }}>
           <PaperStack
             echoes={echoes}
@@ -318,6 +320,7 @@ export default function AnalysisView() {
             patterns={patterns}
             currentPaper={currentPaper}
             onPaperChange={setCurrentPaper}
+            isMobile={isMobile}
           />
         </div>
       </div>
@@ -332,7 +335,7 @@ export default function AnalysisView() {
       overflowY: 'auto',
       background: 'linear-gradient(180deg, #f8f0e6 0%, #ede3d5 100%)',
       fontFamily: "'Excalifont', 'Xiaolai', 'Georgia', serif",
-      padding: '3rem 2rem',
+      padding: isMobile ? '1.75rem 1rem 2.5rem' : '3rem 2rem',
       position: 'relative'
     }}>
       <DecorativeInkSpots />
@@ -345,7 +348,7 @@ export default function AnalysisView() {
           position: 'relative'
         }}>
           <h1 style={{
-            fontSize: '48px',
+            fontSize: isMobile ? '32px' : '48px',
             fontWeight: 400,
             color: '#3d3226',
             marginBottom: '0.75rem',
@@ -364,7 +367,7 @@ export default function AnalysisView() {
             opacity: 0.4
           }} />
           <p style={{
-            fontSize: '15px',
+            fontSize: isMobile ? '14px' : '15px',
             color: '#6b5d4f',
             lineHeight: 1.8,
             fontStyle: 'italic',
@@ -379,7 +382,7 @@ export default function AnalysisView() {
         <div style={{
           display: 'flex',
           justifyContent: 'center',
-          gap: '2rem',
+          gap: isMobile ? '1rem' : '2rem',
           marginBottom: '3rem',
           flexWrap: 'wrap'
         }}>
@@ -405,7 +408,7 @@ export default function AnalysisView() {
             <div style={{
               display: 'grid',
               gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
-              gap: '1.5rem',
+              gap: isMobile ? '1rem' : '1.5rem',
               marginBottom: '2rem'
             }}>
               {savedReports.slice(0, 3).map((report, idx) => (
@@ -676,15 +679,18 @@ function PaperStack({
   traits,
   patterns,
   currentPaper,
-  onPaperChange
+  onPaperChange,
+  isMobile
 }: {
   echoes: Echo[];
   traits: Trait[];
   patterns: Pattern[];
   currentPaper: number;
   onPaperChange: (index: number) => void;
+  isMobile: boolean;
 }) {
   const { t } = useTranslation();
+  const contentMaxHeight = isMobile ? '42vh' : '500px';
   // @@@ Build papers array (only include non-empty ones)
   const papers = [];
 
@@ -698,9 +704,9 @@ function PaperStack({
           display: 'flex',
           flexDirection: 'column',
           gap: '1rem',
-          maxHeight: '500px',
+          maxHeight: contentMaxHeight,
           overflowY: 'auto',
-          paddingRight: '1rem'
+          paddingRight: isMobile ? '0.5rem' : '1rem'
         }}>
           {echoes.map((echo, idx) => (
             <EchoCard key={idx} echo={echo} />
@@ -718,11 +724,11 @@ function PaperStack({
       content: (
         <div style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+          gridTemplateColumns: isMobile ? '1fr' : 'repeat(auto-fill, minmax(280px, 1fr))',
           gap: '1rem',
-          maxHeight: '500px',
+          maxHeight: contentMaxHeight,
           overflowY: 'auto',
-          paddingRight: '1rem'
+          paddingRight: isMobile ? '0.5rem' : '1rem'
         }}>
           {traits.map((trait, idx) => (
             <TraitCard key={idx} trait={trait} />
@@ -742,9 +748,9 @@ function PaperStack({
           display: 'flex',
           flexDirection: 'column',
           gap: '1rem',
-          maxHeight: '500px',
+          maxHeight: contentMaxHeight,
           overflowY: 'auto',
-          paddingRight: '1rem'
+          paddingRight: isMobile ? '0.5rem' : '1rem'
         }}>
           {patterns.map((pattern, idx) => (
             <PatternCard key={idx} pattern={pattern} />
@@ -761,8 +767,8 @@ function PaperStack({
     <div style={{
       position: 'relative',
       width: '100%',
-      maxWidth: '1100px',
-      height: '650px',
+      maxWidth: isMobile ? '520px' : '1100px',
+      height: isMobile ? '520px' : '650px',
       margin: '0 auto',
       perspective: '1200px'
     }}>
@@ -772,10 +778,10 @@ function PaperStack({
         top: '50%',
         left: '50%',
         transform: 'translate(-50%, -50%)',
-        marginLeft: '-30px',
+        marginLeft: isMobile ? '0' : '-30px',
         width: '100%',
-        maxWidth: '900px',
-        height: '600px'
+        maxWidth: isMobile ? '520px' : '900px',
+        height: isMobile ? '480px' : '600px'
       }}>
         {papers.map((paper, idx) => {
           const isActive = idx === currentPaper;
@@ -819,7 +825,7 @@ function PaperStack({
                   inset 0 -1px 0 rgba(139,115,85,0.08)
                 `,
                 border: '1px solid rgba(139,115,85,0.15)',
-                padding: '3rem',
+                padding: isMobile ? '1.5rem' : '3rem',
                 overflow: 'hidden',
                 position: 'relative'
               }}>
@@ -880,7 +886,7 @@ function PaperStack({
                       <span style={{ fontSize: '32px' }}>{paper.icon}</span>
                       <div>
                         <h2 style={{
-                          fontSize: '28px',
+                          fontSize: isMobile ? '22px' : '28px',
                           fontWeight: 400,
                           color: '#3d3226',
                           fontFamily: 'Georgia, serif',
@@ -922,12 +928,12 @@ function PaperStack({
             disabled={currentPaper === 0}
             style={{
               position: 'absolute',
-              left: '50%',
-              marginLeft: '-540px',
+              left: isMobile ? '12px' : '50%',
+              marginLeft: isMobile ? 0 : '-540px',
               top: '50%',
               transform: 'translateY(-50%)',
-              width: '48px',
-              height: '48px',
+              width: isMobile ? '40px' : '48px',
+              height: isMobile ? '40px' : '48px',
               borderRadius: '50%',
               background: currentPaper === 0 ? 'rgba(139,115,85,0.1)' : 'rgba(255,255,255,0.95)',
               border: '2px solid rgba(139,115,85,0.2)',
@@ -935,7 +941,7 @@ function PaperStack({
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontSize: '20px',
+              fontSize: isMobile ? '18px' : '20px',
               color: currentPaper === 0 ? '#ccc' : '#5d4a3a',
               transition: 'all 0.3s',
               boxShadow: currentPaper === 0 ? 'none' : '0 4px 12px rgba(139,115,85,0.15)',
@@ -960,12 +966,13 @@ function PaperStack({
             disabled={currentPaper === totalPapers - 1}
             style={{
               position: 'absolute',
-              left: '50%',
-              marginLeft: '530px',
+              left: isMobile ? 'auto' : '50%',
+              right: isMobile ? '12px' : 'auto',
+              marginLeft: isMobile ? 0 : '530px',
               top: '50%',
               transform: 'translateY(-50%)',
-              width: '48px',
-              height: '48px',
+              width: isMobile ? '40px' : '48px',
+              height: isMobile ? '40px' : '48px',
               borderRadius: '50%',
               background: currentPaper === totalPapers - 1 ? 'rgba(139,115,85,0.1)' : 'rgba(255,255,255,0.95)',
               border: '2px solid rgba(139,115,85,0.2)',
@@ -973,7 +980,7 @@ function PaperStack({
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontSize: '20px',
+              fontSize: isMobile ? '18px' : '20px',
               color: currentPaper === totalPapers - 1 ? '#ccc' : '#5d4a3a',
               transition: 'all 0.3s',
               boxShadow: currentPaper === totalPapers - 1 ? 'none' : '0 4px 12px rgba(139,115,85,0.15)',
@@ -996,7 +1003,7 @@ function PaperStack({
           {/* Paper indicators */}
           <div style={{
             position: 'absolute',
-            bottom: '-40px',
+            bottom: isMobile ? '-24px' : '-40px',
             left: '50%',
             transform: 'translateX(-50%)',
             display: 'flex',

--- a/frontend/src/components/DeckManager.tsx
+++ b/frontend/src/components/DeckManager.tsx
@@ -360,7 +360,7 @@ export default function DeckManager({ onUpdate }: Props) {
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: '#f8f0e6', overflow: 'hidden' }}>
       {/* Scrollable Content with embedded header */}
-      <div ref={scrollContainerRef} style={{ flex: 1, overflowY: 'auto', padding: '32px' }}>
+      <div ref={scrollContainerRef} style={{ flex: 1, overflowY: 'auto', padding: 'clamp(16px, 4vw, 32px)' }}>
         <div style={{ maxWidth: 1200, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 24 }}>
           {/* Embedded Header */}
           <div style={{
@@ -460,8 +460,8 @@ export default function DeckManager({ onUpdate }: Props) {
                     gap: 10,
                     cursor: 'pointer',
                     transition: 'transform 0.15s, box-shadow 0.15s',
-                    flex: '0 0 360px',
-                    minWidth: 320,
+                    flex: '1 1 320px',
+                    minWidth: 0,
                     maxWidth: '100%'
                   }}
                   onMouseEnter={(e) => {
@@ -680,8 +680,8 @@ export default function DeckManager({ onUpdate }: Props) {
                       display: 'flex',
                       flexDirection: 'column',
                       gap: 10,
-                      flex: '0 0 360px',
-                      minWidth: 320,
+                      flex: '1 1 320px',
+                      minWidth: 0,
                       maxWidth: '100%'
                     }}
                     onMouseEnter={(e) => {


### PR DESCRIPTION
  - frontend/src/App.tsx：新增移动端底部导航；写作/时间线/分析/卡组/设置页统一适
    配移动端安全区与底部导航高度；移动端评论弹窗与写作区滚动留出底部空间；底部统
    计条在移动端缩小并允许换行；能量条开关圆点改为右对齐避免溢出。
  - frontend/src/App.css：补了移动端媒体查询，修正书页布局与语音输入浮层在窄屏的
    尺寸和位置。
  - frontend/src/components/DeckManager.tsx：卡片与滚动容器改为自适应宽度与间
    距，避免窄屏溢出。
  - frontend/src/components/CollectionsView.tsx：时间线移动端改为单列居中卡片、
    缩小卡片宽度；时间线点居中；恢复并细化中线；图片预览弹窗在移动端改为纵向布局
    并缩紧内边距。
  - frontend/src/components/AnalysisView.tsx：引入移动端检测，缩小报告页与
    dashboard 的排版尺寸；纸张堆栈在移动端收窄、内容高度自适应，导航按钮靠边显
    示，traits 网格在移动端单列。